### PR TITLE
Make compatible with Webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,28 @@ npm install monkberry-loader --save
 module.exports = {
   ...
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.monk$/,
-        loader: 'monkberry-loader'
+        use: [
+          {
+            loader: 'monkberry-loader',
+            options: { /* ... */ }
+          }
+        ],
       }
     ]
   },
   ...
-};
+}
 ```
 
-## Configuration 
+## Configuration (optional)
 
-Add `monkberry` section to your `webpack.config.js`:
+Add `monkberry` options to your `webpack.config.js`:
 
 ```js
-monkberry: {
+options: {
   globals: ['window'],
   transforms: [...]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monkberry-loader",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Monkberry loader for webpack",
   "main": "src/index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/monkberry/monkberry-loader#readme",
   "dependencies": {
-    "loader-utils": "^0.2.15"
+    "loader-utils": "^1.1.0"
   },
   "peerDependencies": {
     "monkberry": "4.x"

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,16 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function (content) {
   this.cacheable();
-  var config = loaderUtils.getLoaderConfig(this, 'monkberry');
+  var options = loaderUtils.getOptions(this) || {};
 
   var compiler = new Compiler();
 
-  if (config.globals) {
-    compiler.globals = config.globals;
+  if (options.globals) {
+    compiler.globals = options.globals;
   }
 
-  if (config.transforms) {
-    config.transforms.forEach(function (transform) {
+  if (options.transforms) {
+    options.transforms.forEach(function (transform) {
       compiler.transforms.push(transform);
     });
   }


### PR DESCRIPTION
NB: Still work with Webpack 3.
I'm unsure on which release version I should choose. There is a breaking change in `webpack.config.js`, the user must use local `options` instead of a root section.